### PR TITLE
fixup for the vwifi-client service

### DIFF
--- a/package/vwifi/files/etc/init.d/vwifi-client
+++ b/package/vwifi/files/etc/init.d/vwifi-client
@@ -13,7 +13,10 @@ log_msg() {
 
 start_service() {
 	local enabled server_ip number mac_prefix
-    insmod mac80211_hwsim radios=0
+	# First remove mac80211_hwsim
+	rmmod mac80211_hwsim
+	# Reinsert it with the correct amount of radios
+	insmod mac80211_hwsim radios=0
     log_msg "info" "Re-inserted mac80211_hwsim module"
 	config_load vwifi
 	config_get enabled config 'enabled' '0'

--- a/package/vwifi/files/etc/modules.d/mac80211-hwsim
+++ b/package/vwifi/files/etc/modules.d/mac80211-hwsim
@@ -1,1 +1,0 @@
-mac80211_hwsim radios=0


### PR DESCRIPTION
Service is always started after mac80211_hwsim is inserted, meaning it will be inserted with the default amount of radios (2). 
So we first need to remove then reinsert the module.

Also removed the module.d/ directory because  it was causing issues at compilation (overriding mac80211_hwsim configuration)