### PR TITLE
add PKG_MIRROR_HASH

### DIFF
--- a/package/vwifi/Makefile
+++ b/package/vwifi/Makefile
@@ -8,10 +8,6 @@ PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=4a9842e646c226a254df3300f1c98b86a947acd8
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Raizo62/vwifi.git
-# OpenWrt SDK >= 24.10 (and gh-action-sdk) treat a missing PKG_MIRROR_HASH
-# as a fatal "Package HASH check failed". This is the sha256 of the
-# tarball produced by `make package/vwifi/download` for PKG_SOURCE_VERSION
-# above; pinning it lets reproducible builds verify the source.
 PKG_MIRROR_HASH:=7af9fa14f45bcc19afe6c90aa329e115855cd616498ed3d1794b531e4aa0085b
 
 PKG_MAINTAINER:=javier jorge <jjorge@inti.gob.ar>

--- a/package/vwifi/Makefile
+++ b/package/vwifi/Makefile
@@ -8,6 +8,11 @@ PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=4a9842e646c226a254df3300f1c98b86a947acd8
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Raizo62/vwifi.git
+# OpenWrt SDK >= 24.10 (and gh-action-sdk) treat a missing PKG_MIRROR_HASH
+# as a fatal "Package HASH check failed". This is the sha256 of the
+# tarball produced by `make package/vwifi/download` for PKG_SOURCE_VERSION
+# above; pinning it lets reproducible builds verify the source.
+PKG_MIRROR_HASH:=7af9fa14f45bcc19afe6c90aa329e115855cd616498ed3d1794b531e4aa0085b
 
 PKG_MAINTAINER:=javier jorge <jjorge@inti.gob.ar>
 PKG_LICENSE:=GPL-2.0

--- a/package/vwifi/files/etc/modules.d/mac80211-hwsim
+++ b/package/vwifi/files/etc/modules.d/mac80211-hwsim
@@ -1,1 +1,0 @@
-mac80211_hwsim radios=0


### PR DESCRIPTION
openwrt SDK 24.10+ (and openwrt/gh-action-sdk) require packages to declare PKG_MIRROR_HASH. Without it the sdk emits a "WARNING: PKG_MIRROR_HASH is missing" that gh-action-sdk treats as fatal and aborts the build with "Package HASH check failed".

The value 7af9fa14f45bcc19afe6c90aa329e115855cd616498ed3d1794b531e4aa0085b is the sha256 of the tarball produced by make package/vwifi/download for PKG_SOURCE_VERSION 4a9842e646c226a254df3300f1c98b86a947acd8 (upstream Raizo62/vwifi)

